### PR TITLE
Add clickup link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # blockchain-hyperledger-fabric-electronic-patient-records
 
 Project report will be uploaded soon.
+
+**Project Management**
+
+> https://share.clickup.com/l/h/4-6668897-1/8922645f320f3c0
+
+> From April 1st 2021 all the project managment to be done in Github. (All the issues to be created on Github). 


### PR DESCRIPTION
From April 1st. I would like to store all the issues to be in Github. clickup will no longer be necessary.