### PR TITLE
Cu fq22pd integrate jwt refresh token with angular and consume doctor details api

### DIFF
--- a/app/client/src/app/app.component.html
+++ b/app/client/src/app/app.component.html
@@ -24,7 +24,7 @@
       <li class="nav-item">
         <a class="nav-link fa fa-sign-in" *ngIf="!authService.loggedIn()" routerLink="/login" routerLinkActive="active">&nbsp;Login</a>
         <a class="nav-link fa fa-sign-out mr-2" style="cursor: pointer" *ngIf="authService.loggedIn()"
-          (click)="authService.logoutUser()">
+          (click)="logoutUser()">
           Logout
         </a>
       </li>

--- a/app/client/src/app/app.component.ts
+++ b/app/client/src/app/app.component.ts
@@ -1,17 +1,25 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
+
+import { Subscription } from 'rxjs';
 
 import { AuthService } from './core/auth/auth.service';
 import { RoleEnum } from './utils';
+
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   title = 'client';
+  private sub?: Subscription;
 
   constructor(public authService: AuthService) {
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
   }
 
   public isPatient(): boolean {
@@ -28,5 +36,12 @@ export class AppComponent {
 
   public getUsername(): string {
     return this.authService.getUsername();
+  }
+
+  public logoutUser(): void {
+    this.sub = this.authService.logout().subscribe(
+      (res: any) => this.authService.logoutUser(),
+      (err: any) => console.error(err)
+    );
   }
 }

--- a/app/client/src/app/core/auth/auth.service.ts
+++ b/app/client/src/app/core/auth/auth.service.ts
@@ -38,10 +38,11 @@ export class AuthService {
         }));
   }
 
-  public setHeaders(res: any, role: string, username: string): void {
+  public setHeaders(res: any, role: string, hospitalId: number, username: string): void {
     localStorage.setItem(BrowserStorageFields.TOKEN, res.accessToken);
     localStorage.setItem(BrowserStorageFields.REFRESH_TOKEN, res.refreshToken);
     localStorage.setItem(BrowserStorageFields.USER_ROLE, role);
+    localStorage.setItem(BrowserStorageFields.HOSPITAL_ID, String(hospitalId));
     localStorage.setItem(BrowserStorageFields.USERNAME, username);
   }
 
@@ -71,6 +72,10 @@ export class AuthService {
     return localStorage.getItem(BrowserStorageFields.USER_ROLE) as string;
   }
 
+  public getHospitalId(): string {
+    return JSON.parse(localStorage.getItem(BrowserStorageFields.HOSPITAL_ID) as string);
+  }
+
   public getUsername(): string {
     return localStorage.getItem(BrowserStorageFields.USERNAME) as string;
   }
@@ -79,6 +84,7 @@ export class AuthService {
     localStorage.removeItem(BrowserStorageFields.TOKEN);
     localStorage.removeItem(BrowserStorageFields.REFRESH_TOKEN);
     localStorage.removeItem(BrowserStorageFields.USER_ROLE);
+    localStorage.removeItem(BrowserStorageFields.HOSPITAL_ID);
     localStorage.removeItem(BrowserStorageFields.USERNAME);
   }
 }

--- a/app/client/src/app/core/auth/auth.service.ts
+++ b/app/client/src/app/core/auth/auth.service.ts
@@ -52,6 +52,10 @@ export class AuthService {
     this.router.navigate(['/login']);
   }
 
+  public logout(): any {
+    return this.http.delete(this.serverUrl + '/logout');
+  }
+
   public loggedIn(): boolean {
     return !!localStorage.getItem(BrowserStorageFields.TOKEN);
   }

--- a/app/client/src/app/core/auth/token-interceptor.service.ts
+++ b/app/client/src/app/core/auth/token-interceptor.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Injector } from '@angular/core';
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 
-import { Observable } from 'rxjs';
+import { Observable, of, Subject, throwError } from 'rxjs';
+import { catchError, switchMap, tap } from 'rxjs/operators';
 
 import { AuthService } from './auth.service';
 
@@ -9,19 +10,82 @@ import { AuthService } from './auth.service';
   providedIn: 'root'
 })
 export class TokenInterceptorService implements HttpInterceptor {
+  private refreshTokenInProgress = false;
+  private accessTokenRefreshed: Subject<any> = new Subject();
+  private authService: AuthService;
 
-  constructor(private injector: Injector) { }
+  constructor(private injector: Injector) {
+    this.authService = this.injector.get(AuthService);
+  }
 
-  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const authService = this.injector.get(AuthService);
-    const tokenizedRequest = req.clone({
-      setHeaders: {
-        Authorization: `Bearer ${authService.getToken()}`,
-        Role: `${authService.getRole()}`,
-        username: `${authService.getUsername()}`
-      }
-    });
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<any> {
+    req = this.addAuthHeader(req);
 
-    return next.handle(tokenizedRequest);
+    return next.handle(req).pipe(
+      catchError(err => {
+        if (err.status !== 401 && err.status !== 403) {
+          return throwError(err.message);
+        }
+
+        return this.refreshAccessToken()
+          .pipe(
+            switchMap(() => {
+              req = this.addAuthHeader(req);
+
+              return next.handle(req);
+            }),
+            catchError((e: any) => {
+              console.error(e);
+              this.authService.logoutUser();
+
+              return of({});
+            })
+          );
+      })
+    );
+  }
+
+  private refreshAccessToken(): Observable<any> {
+    if (this.refreshTokenInProgress) {
+      return new Observable(observer => {
+        this.accessTokenRefreshed.subscribe(() => {
+          // this code will run when the access token has been refreshed
+          observer.next();
+          observer.complete();
+        });
+      });
+    } else {
+      this.refreshTokenInProgress = true;
+      return this.authService.getNewAccessToken().pipe(
+        tap(() => {
+          console.log('Access Token Refreshed!');
+          this.refreshTokenInProgress = false;
+          this.accessTokenRefreshed.next();
+        })
+      );
+    }
+  }
+
+  private addAuthHeader(request: HttpRequest<any>): HttpRequest<any>{
+    if (request.url.includes('token')) {
+      return request.clone({
+        setHeaders: {
+          Role: `${this.authService.getRole()}`
+        }
+      });
+    }
+
+    const token = this.authService.getToken();
+    if (token) {
+      return request.clone({
+        setHeaders: {
+          Authorization: `Bearer ${token}`,
+          Role: `${this.authService.getRole()}`,
+          username: `${this.authService.getUsername()}`
+        }
+      });
+    }
+
+    return request;
   }
 }

--- a/app/client/src/app/core/auth/token-interceptor.service.ts
+++ b/app/client/src/app/core/auth/token-interceptor.service.ts
@@ -75,6 +75,14 @@ export class TokenInterceptorService implements HttpInterceptor {
       });
     }
 
+    if (request.url.includes('logout')) {
+      return request.clone({
+        setHeaders: {
+          token: `${this.authService.getRefreshToken()}`
+        }
+      });
+    }
+
     const token = this.authService.getToken();
     if (token) {
       return request.clone({

--- a/app/client/src/app/doctor/doctor.component.html
+++ b/app/client/src/app/doctor/doctor.component.html
@@ -4,3 +4,38 @@
   <app-toolbar-button text="Refresh" icon="refresh" (click)="refresh()"></app-toolbar-button>
 </app-toolbar>
 <br><br><br>
+
+<div class="sidebar-layout-bottom-row p-3 container-fluid">
+  <div class="row">
+    <div class="col-xl-6 col-sm-12">
+      <div class="card">
+        <div class="card-body">
+          <h5 class="card-title">Details</h5>
+          <table *ngIf="doctorRecordObs | async as record">
+            <span>
+              <tr>
+                <td class="labels"><strong>Doctor ID</strong></td>
+                <td>{{doctorId}}</td>
+              </tr>
+              <tr>
+                <td class="labels"><strong>First Name</strong></td>
+                <td>{{record.firstName}}</td>
+              </tr>
+              <tr>
+                <td class="labels"><strong>Last Name</strong></td>
+                <td>{{record.lastName}}</td>
+              </tr>
+              <tr>
+                <td class="labels"><strong>Speciality</strong></td>
+                <td>{{record.speciality}}</td>
+              </tr>
+            </span>
+          </table>
+          <div *ngIf="doctorRecordObs === undefined">
+            <p>You are not authorized to view doctor details.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/client/src/app/doctor/doctor.component.ts
+++ b/app/client/src/app/doctor/doctor.component.ts
@@ -39,7 +39,7 @@ export class DoctorComponent implements OnInit, OnDestroy {
   }
 
   public refresh(): void {
-    this.doctorRecordObs = this.doctorService.getDoctorByHospitalId(1, this.doctorId);
+    this.doctorRecordObs = this.doctorService.getDoctorByHospitalId(this.authService.getHospitalId(), this.doctorId);
   }
 
   public isDoctor(): boolean {

--- a/app/client/src/app/doctor/doctor.component.ts
+++ b/app/client/src/app/doctor/doctor.component.ts
@@ -27,7 +27,7 @@ export class DoctorComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.route.params
+    this.sub = this.route.params
       .subscribe((params: Params) => {
         this.doctorId = params.doctorId;
         this.refresh();

--- a/app/client/src/app/doctor/doctor.component.ts
+++ b/app/client/src/app/doctor/doctor.component.ts
@@ -1,16 +1,29 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
+
+import { Observable, Subscription } from 'rxjs';
+
+import { RoleEnum } from '../utils';
+import { AuthService } from '../core/auth/auth.service';
+
+import { DoctorViewRecord } from './doctor';
+import { DoctorService } from './doctor.service';
+
 
 @Component({
   selector: 'app-doctor',
   templateUrl: './doctor.component.html',
   styleUrls: ['./doctor.component.scss']
 })
-export class DoctorComponent implements OnInit {
+export class DoctorComponent implements OnInit, OnDestroy {
   public doctorId: any;
+  public doctorRecordObs?: Observable<DoctorViewRecord>;
+  private sub?: Subscription;
 
   constructor(
-    private readonly route: ActivatedRoute
+    private readonly route: ActivatedRoute,
+    private readonly doctorService: DoctorService,
+    private readonly authService: AuthService
   ) { }
 
   ngOnInit(): void {
@@ -21,7 +34,15 @@ export class DoctorComponent implements OnInit {
       });
   }
 
-  public refresh(): void {
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
 
+  public refresh(): void {
+    this.doctorRecordObs = this.doctorService.getDoctorByHospitalId(1, this.doctorId);
+  }
+
+  public isDoctor(): boolean {
+    return this.authService.getRole() === RoleEnum.DOCTOR;
   }
 }

--- a/app/client/src/app/doctor/doctor.service.ts
+++ b/app/client/src/app/doctor/doctor.service.ts
@@ -20,7 +20,7 @@ export class DoctorService {
     return this.http.get(this.doctorURL + `/${hospitalId}/_all`);
   }
 
-  public getDoctorByHospitalId(hospitalId: number, docId: any): Observable<any> {
+  public getDoctorByHospitalId(hospitalId: string, docId: any): Observable<any> {
     return this.http.get(this.doctorURL + `/${hospitalId}/${docId}`);
   }
 }

--- a/app/client/src/app/doctor/doctor.service.ts
+++ b/app/client/src/app/doctor/doctor.service.ts
@@ -19,4 +19,8 @@ export class DoctorService {
   public getDoctorsByHospitalId(hospitalId: number): Observable<any> {
     return this.http.get(this.doctorURL + `/${hospitalId}/_all`);
   }
+
+  public getDoctorByHospitalId(hospitalId: number, docId: any): Observable<any> {
+    return this.http.get(this.doctorURL + `/${hospitalId}/${docId}`);
+  }
 }

--- a/app/client/src/app/doctor/doctor.ts
+++ b/app/client/src/app/doctor/doctor.ts
@@ -9,6 +9,7 @@ export class DoctorViewRecord {
   doctorId = '';
   firstName = '';
   lastName = '';
+  speciality = '';
   role = '';
 
   constructor(readonly doctorRecord: DoctorRecord) {

--- a/app/client/src/app/login/login.component.ts
+++ b/app/client/src/app/login/login.component.ts
@@ -87,11 +87,10 @@ export class LoginComponent implements OnInit {
       return;
     }
 
-    localStorage.setItem(BrowserStorageFields.TOKEN, res.accessToken);
     const role = this.role;
-    localStorage.setItem(BrowserStorageFields.USER_ROLE, this.role);
     const userId = this.username;
-    localStorage.setItem(BrowserStorageFields.USERNAME, this.username);
+    const hospitalId = this.hospitalId;
+    this.authService.setHeaders(res, role, hospitalId, userId);
 
     this.resetFields();
 

--- a/app/client/src/app/utils.ts
+++ b/app/client/src/app/utils.ts
@@ -8,6 +8,7 @@ export enum BrowserStorageFields {
   TOKEN = 'token',
   REFRESH_TOKEN = 'refreshToken',
   USER_ROLE = 'role',
+  HOSPITAL_ID = 'hospitalId',
   USERNAME = 'username'
 }
 export class Utils {

--- a/app/client/src/app/utils.ts
+++ b/app/client/src/app/utils.ts
@@ -5,7 +5,8 @@ export enum RoleEnum {
 }
 
 export enum BrowserStorageFields {
-  TOKEN= 'token',
+  TOKEN = 'token',
+  REFRESH_TOKEN = 'refreshToken',
   USER_ROLE = 'role',
   USERNAME = 'username'
 }

--- a/app/server/src/server.js
+++ b/app/server/src/server.js
@@ -173,7 +173,7 @@ app.post('/token', (req, res) => {
  * @description Logout to remove refreshTokens
  */
 app.delete('/logout', (req, res) => {
-  refreshTokens = refreshTokens.filter((token) => token !== req.body.token);
+  refreshTokens = refreshTokens.filter((token) => token !== req.headers.token);
   res.sendStatus(204);
 });
 

--- a/app/server/src/server.js
+++ b/app/server/src/server.js
@@ -184,12 +184,12 @@ app.post('/patients/register', authenticateJWT, adminRoutes.createPatient);
 
 // //////////////////////////////// Doctor Routes //////////////////////////////////////
 app.patch('/patients/:patientId/details/medical', authenticateJWT, doctorRoutes.updatePatientMedicalDetails);
-app.get('/doctors/:hospitalId/:doctorId', authenticateJWT, doctorRoutes.getDoctorById);
+app.get('/doctors/:hospitalId([0-9]+)/:doctorId(HOSP[0-9]+\-DOC[0-9]+)', authenticateJWT, doctorRoutes.getDoctorById);
 
 // //////////////////////////////// Patient Routes //////////////////////////////////////
 app.get('/patients/:patientId', authenticateJWT, patientRoutes.getPatientById);
 app.patch('/patients/:patientId/details/personal', authenticateJWT, patientRoutes.updatePatientPersonalDetails);
 app.get('/patients/:patientId/history', authenticateJWT, patientRoutes.getPatientHistoryById);
-app.get('/doctors/:hospitalId/_all', authenticateJWT, patientRoutes.getDoctorsByHospitalId);
+app.get('/doctors/:hospitalId([0-9]+)/_all', authenticateJWT, patientRoutes.getDoctorsByHospitalId);
 app.patch('/patients/:patientId/grant/:doctorId', authenticateJWT, patientRoutes.grantAccessToDoctor);
 app.patch('/patients/:patientId/revoke/:doctorId', authenticateJWT, patientRoutes.revokeAccessFromDoctor);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58306871/111237847-34d8bb00-85f6-11eb-8676-18225eece7ba.png)

CU-fq22pd Consumed doctor details REST API
(+) add doctor details template html
(+) new field 'speciality'
(+) called new API to get response


CU-fq22pd Refresh token in front end 
(+) new methods to fetch access tokens
(+) separate method to add token in headers
(+) separate methods to add and clear headers on login and logout
(*) server.js refactoring

CU-fq22pd Set hospital id in headers 
(+) new method to fetch hospital id
(+) regex for doctors API